### PR TITLE
Fix after update pcvl 0.10

### DIFF
--- a/ClassificationTask.ipynb
+++ b/ClassificationTask.ipynb
@@ -73,6 +73,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ecf9b13d-b6f8-4bc9-9dc5-20aa4520cf0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pcvl.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "7030f84a",
    "metadata": {},
    "outputs": [],
@@ -97,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qpu_token = ''"
+    "qpu_token = '_T_eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTc3LCJleHAiOjE3MDg2MDI4MzV9.cVxctsFHAVsh5AFSGHEjOKZIZB7WxqkY8fo5VAmQQdz9v6aInr0__K19ip2xKFHyXimfIdy7Myljpz1Os3l0Yg'"
    ]
   },
   {
@@ -115,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_on_qpu = True"
+    "run_on_qpu = False"
    ]
   },
   {
@@ -189,6 +199,18 @@
     "        \n",
     "        # Choose number of samples per experiment\n",
     "        self.n_samples = 5*1e4\n",
+    "\n",
+    "        # Define max number of shots if run on QPU, with some margin\n",
+    "        if run_on_qpu:\n",
+    "            # Define simple circuit to get the estimate\n",
+    "            remote_qpu = pcvl.RemoteProcessor(\"qpu:ascella\", qpu_token)\n",
+    "            remote_qpu.set_circuit(pcvl.Circuit(9))\n",
+    "            remote_qpu.with_input(pcvl.BasicState([0, 0, 1, 0, 1, 0, 1, 0, 0]))\n",
+    "            remote_qpu.min_detected_photons_filter(3)\n",
+    "            # Get estimated required number of shots\n",
+    "            required_shots = remote_qpu.estimate_required_shots(nsamples=self.n_samples)\n",
+    "            # Assign with a margin factor of 10\n",
+    "            self.required_shots = required_shots * 10\n",
     "        \n",
     "        # Define empty lists for the outcomes and probabilities and for the estimator \n",
     "        self.outcomes = []\n",
@@ -454,7 +476,12 @@
     "        self.processor.set_circuit(self.circuit)\n",
     "        self.processor.with_input(initial_state)\n",
     "        self.processor.set_parameter(\"parameter_iterator\", list_data_phases)\n",
-    "        sampler = pcvl.algorithm.Sampler(self.processor)\n",
+    "        \n",
+    "        if run_on_qpu:\n",
+    "            sampler = pcvl.algorithm.Sampler(self.processor, max_shots_per_call=self.required_shots)\n",
+    "        else:\n",
+    "            sampler = pcvl.algorithm.Sampler(self.processor)\n",
+    "            \n",
     "        remote_job = sampler.sample_count\n",
     "        remote_job.name = \"vqc_\" + datetime.now().strftime(\"%Y%m%d_%H%M%S\")\n",
     "        remote_job.execute_async(self.n_samples)\n",
@@ -500,7 +527,12 @@
     "\n",
     "        self.processor.set_circuit(self.circuit)\n",
     "        self.processor.with_input(initial_state)\n",
-    "        sampler = pcvl.algorithm.Sampler(self.processor)\n",
+    "        \n",
+    "        if run_on_qpu:\n",
+    "            sampler = pcvl.algorithm.Sampler(self.processor, max_shots_per_call=self.required_shots)\n",
+    "        else:\n",
+    "            sampler = pcvl.algorithm.Sampler(self.processor)\n",
+    "\n",
     "        remote_job = sampler.sample_count\n",
     "        remote_job.name = \"vqc_\" + datetime.now().strftime(\"%Y%m%d_%H%M%S\")\n",
     "        remote_job.execute_async(self.n_samples)\n",
@@ -667,9 +699,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "85891ef8",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "theta_optimisation_space = [sk.space.space.Real(0, 2*np.pi) for _ in range(len(Classifier.theta_phases))]\n",
@@ -687,7 +717,7 @@
     "\n",
     "# Split the data - each batch will be sent as one job to the QPU \n",
     "# The split is needed in order to stay below the runtime limit\n",
-    "n_splits = 4\n",
+    "n_splits = 10\n",
     "split_data = np.array_split(Classifier.X_train, n_splits)\n",
     "\n",
     "for i in range(15):\n",

--- a/ClassificationTask.ipynb
+++ b/ClassificationTask.ipynb
@@ -107,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qpu_token = '_T_eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTc3LCJleHAiOjE3MDg2MDI4MzV9.cVxctsFHAVsh5AFSGHEjOKZIZB7WxqkY8fo5VAmQQdz9v6aInr0__K19ip2xKFHyXimfIdy7Myljpz1Os3l0Yg'"
+    "qpu_token = ''"
    ]
   },
   {
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_on_qpu = False"
+    "run_on_qpu = True"
    ]
   },
   {


### PR DESCRIPTION
In Perceval 0.10 a new argument for remote jobs was introduced with max_shots_per_call. As it is a required argument, it made the notebook in its previous state fail. 

The changes made here should fix it.